### PR TITLE
Fix DAC manifest

### DIFF
--- a/manifests/dac-dunfell-3.1.6-manifest.xml
+++ b/manifests/dac-dunfell-3.1.6-manifest.xml
@@ -31,7 +31,8 @@
 
   <project remote="oe-org"
              name="meta-openembedded"
-         revision="dunfell"
+         upstream="dunfell"
+         revision="ca35402be56745e5664394b8ec18d7e2a3b353d1"
              path="meta-openembedded"/>
 
   <project remote="yocto"


### PR DESCRIPTION
* take fixed revision for meta-openembedded to avoid this newer change:
  https://github.com/openembedded/meta-openembedded/commit/7889158dcd187546fc5e99fd81d0779cad3e8d17
* the new syntax used in there causes yocto parse error
  for the version we are using